### PR TITLE
feat: add shuffle option

### DIFF
--- a/src/commands/utility/generate.js
+++ b/src/commands/utility/generate.js
@@ -48,6 +48,7 @@ module.exports = {
           { name: "Pop", value: "pop" },
           { name: "Rap", value: "rap" }
         )
+        .setRequired(false)
     )
     .addStringOption((option) =>
       option
@@ -65,6 +66,7 @@ module.exports = {
       option
         .setName("channel")
         .setDescription("Enter the name of the YouTube Channel.")
+        .setRequired(false)
     )
     .addStringOption((option) =>
       option
@@ -74,6 +76,7 @@ module.exports = {
           { name: "Yes", value: "true" },
           { name: "No", value: "false" }
         )
+        .setRequired(false)
     )
     .addStringOption((option) =>
       option
@@ -81,11 +84,13 @@ module.exports = {
         .setDescription(
           "Popular verse? Paste them in here. Limit is 3, separate them by commas."
         )
+        .setRequired(false)
     )
     .addStringOption((option) =>
       option
         .setName("tiktok")
         .setDescription('Is the song popular on TikTok? Type "true" if so.')
+        .setRequired(false)
     ),
 
   async execute(interaction) {

--- a/src/commands/utility/generate.js
+++ b/src/commands/utility/generate.js
@@ -68,6 +68,15 @@ module.exports = {
     )
     .addStringOption((option) =>
       option
+        .setName("shuffle")
+        .setDescription("Shuffle generated tags option.")
+        .setChoices(
+          { name: "Yes", value: "true" },
+          { name: "No", value: "false" }
+        )
+    )
+    .addStringOption((option) =>
+      option
         .setName("verse")
         .setDescription(
           "Popular verse? Paste them in here. Limit is 3, separate them by commas."
@@ -81,6 +90,7 @@ module.exports = {
 
   async execute(interaction) {
     try {
+      const shuffle = interaction.options.getString("shuffle") || "true";
       const features = interaction.options.getString("features") || "";
       const channel = interaction.options.getString("channel") || "";
       const artist = interaction.options.getString("artist") || "";
@@ -186,7 +196,7 @@ module.exports = {
         format: format || "lyrics",
         title: title || "none",
         genre: genre || "none",
-        shuffle: "true",
+        shuffle: shuffle,
       });
 
       const apiUrl = `https://tags.notnick.io/api/v1/generate?${params.toString()}`;


### PR DESCRIPTION
This pull request enhances the `generate` command by introducing an option to control whether generated tags should be shuffled. The main changes involve adding a new `shuffle` option to the command, handling its value in the command logic, and passing it to the API request.

**New feature: Shuffle option for generated tags**
- Added a `shuffle` string option to the `generate` command, allowing users to specify whether to shuffle generated tags, with choices "Yes" (true) or "No" (false).
- Updated the command execution logic to retrieve the `shuffle` option from user input, defaulting to "true" if not provided.
- Modified the API request parameters to use the selected value of `shuffle` instead of always defaulting to "true".