### PR TITLE
feat: add 'dance' and 'none' options to format and genre

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 config.json
+.DS_Store
 .env

--- a/src/commands/utility/generate.js
+++ b/src/commands/utility/generate.js
@@ -31,7 +31,8 @@ module.exports = {
           { name: "Slowed/Reverb", value: "slowed" },
           { name: "Letra", value: "letra" },
           { name: "Testo", value: "testo" },
-          { name: "Phonk", value: "phonk" }
+          { name: "Phonk", value: "phonk" },
+          { name: "None", value: "none" }
         )
         .setRequired(false)
     )
@@ -43,6 +44,7 @@ module.exports = {
           { name: "None", value: "none" },
           { name: "Country", value: "country" },
           { name: "Latin", value: "latin" },
+          { name: "Dance", value: "dance" },
           { name: "Italian", value: "italian" },
           { name: "Phonk", value: "phonk" },
           { name: "Pop", value: "pop" },


### PR DESCRIPTION
This pull request makes minor improvements to the `generate` command by expanding the available options for users. The changes add a "None" option for effects and introduce a new "Dance" genre.

**Enhancements to command options:**

* Added a "None" option to the effects choices, allowing users to select no effect if desired. (`src/commands/utility/generate.js`)
* Added "Dance" to the list of available genres for generation. (`src/commands/utility/generate.js`)